### PR TITLE
fix level meter rms calculation

### DIFF
--- a/system_modules/napaudio/src/audio/node/levelmeternode.cpp
+++ b/system_modules/napaudio/src/audio/node/levelmeternode.cpp
@@ -42,7 +42,7 @@ namespace nap
 
 		float LevelMeterNode::getLevel()
 		{
-			return mValue.load();
+			return mType == RMS ? sqrt(mValue.load()) : mValue.load();
 		}
 
 


### PR DESCRIPTION
I forgot to add a square root when rewriting the RMS implementation in LevelMeterNode!

I decided to add the sqrt() call in the getter as opposed to in the calculate-function to not impact the audio thread performance.

I will do a PR to NAP too.